### PR TITLE
Removed body when null to avoid 400 Bad Request

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -120,13 +120,12 @@ class Box
         try {
             $client = new Client;
 
-            $response = $client->$type($this->baseUrl.$request, [
+            $response = $client->$type($this->baseUrl.$request, array_merge([
                 'headers' => [
                     'Authorization' => 'Bearer '.$this->getAccessToken(),
                     'content-type' => 'application/json',
-                ],
-                'body' => json_encode($data),
-            ]);
+                ]
+            ], empty($data) ? [] : ['body' => json_encode($data)]));
 
             return json_decode($response->getBody()->getContents(), true);
         } catch (ClientException $e) {


### PR DESCRIPTION
I found that when doing GET requests you get a 400 Bad Request response if the body is set to null. Not 100% sure whether this might be a side-effect from a guzzle change. Either way omitting the body from the request resolves the issue.