### PR TITLE
Altera a condição de expiração do token

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,18 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="MessDetectorValidationInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="customRulesets">
+        <list>
+          <RulesetDescriptor>
+            <option name="name" value="Code Size Rules" />
+            <option name="path" value="$USER_HOME$/JetBrains/phpmd.xml" />
+          </RulesetDescriptor>
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PhpCSValidationInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="EXTENSIONS" value="php,js,css,inc" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/laravel-box.iml
+++ b/.idea/laravel-box.iml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Dcblogdev\Box\" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/guzzlehttp/guzzle" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/guzzlehttp/promises" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/guzzlehttp/psr7" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/http-message" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/ralouphie/getallheaders" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/laravel-box.iml" filepath="$PROJECT_DIR$/.idea/laravel-box.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpIncludePathManager">
+    <include_path>
+      <path value="$PROJECT_DIR$/vendor/guzzlehttp/psr7" />
+      <path value="$PROJECT_DIR$/vendor/guzzlehttp/promises" />
+      <path value="$PROJECT_DIR$/vendor/psr/http-message" />
+      <path value="$PROJECT_DIR$/vendor/composer" />
+      <path value="$PROJECT_DIR$/vendor/guzzlehttp/guzzle" />
+      <path value="$PROJECT_DIR$/vendor/ralouphie/getallheaders" />
+    </include_path>
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.2" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "agilize/laravel-box",
+    "name": "agilizedms/laravel-box",
     "description": "A Laravel Box package",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,14 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "David Carr",
+            "name": "OriginalAuthor - David Carr",
             "email": "dave@dcblog.dev",
             "homepage": "https://dcblog.dev"
+        },
+        {
+            "name": "Modify By - Rafael Marques",
+            "email": "rafael.marques@agilize.com.br",
+            "homepage": "https://agilize.com.br"
         }
     ],
     "homepage": "https://github.com/dcblogdev/laravel-box",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dcblogdev/laravel-box",
+    "name": "agilize/laravel-box",
     "description": "A Laravel Box package",
     "license": "MIT",
     "authors": [

--- a/src/Box.php
+++ b/src/Box.php
@@ -8,6 +8,7 @@ use Dcblogdev\Box\Resources\Files;
 use Dcblogdev\Box\Models\BoxToken;
 use GuzzleHttp\Client;
 use Exception;
+use GuzzleHttp\Exception\BadResponseException;
 
 class Box
 {
@@ -129,8 +130,8 @@ class Box
 
             return json_decode($response->getBody()->getContents(), true);
 
-        } catch (Exception $e) {
-            throw new Exception($e->getMessage());
+        } catch (BadResponseException $e) {
+            throw new BadResponseException($e->getMessage(),$e->getRequest(),$e->getResponse());
         }
     }
 

--- a/src/Box.php
+++ b/src/Box.php
@@ -13,6 +13,8 @@ use GuzzleHttp\Psr7\Response;
 
 class Box
 {
+    const ERROR_MARGIN = 100;
+
     const METHOD_GET = 'get';
 
     public function files(): object
@@ -65,7 +67,9 @@ class Box
 
             $token = $this->dopost(config('box.urlAccessToken'), $params);
 
-            $this->storeToken($token->access_token, $token->refresh_token, $token->expires_in);
+            $expires = time() + intval($token->expires_in) - self::ERROR_MARGIN;
+
+            $this->storeToken($token->access_token, $token->refresh_token, $expires);
 
             return $this->redirect(config('box.boxLandingUri'));
         }
@@ -99,8 +103,10 @@ class Box
             ];
             $accessToken = $this->dopost(config('box.urlAccessToken'), $params);
 
+            $expires = time() + intval($accessToken->expires_in) - self::ERROR_MARGIN;
+
             // Store the new values
-            $this->storeToken($accessToken->access_token, $accessToken->refresh_token, $accessToken->expires_in);
+            $this->storeToken($accessToken->access_token, $accessToken->refresh_token, $expires);
 
             return $accessToken->access_token;
         }

--- a/src/Box.php
+++ b/src/Box.php
@@ -13,6 +13,8 @@ use GuzzleHttp\Psr7\Response;
 
 class Box
 {
+    const METHOD_GET = 'get';
+
     public function files(): object
     {
         return new Files();
@@ -129,8 +131,11 @@ class Box
                     'content-type' => 'application/json',
                 ],
                 'allow_redirects' => $allowRedirects,
-                'body' => json_encode($data),
             ];
+
+            if (!is_null($data) && !empty($data)) {
+                $config['body'] = json_encode($data);
+            }
 
             $response = $client->$type($this->baseUrl . $request, $config);
 

--- a/src/Box.php
+++ b/src/Box.php
@@ -29,9 +29,10 @@ class Box
         $options = ['get', 'post', 'patch', 'put', 'delete'];
         $path = (isset($args[0])) ? $args[0] : null;
         $data = (isset($args[1])) ? $args[1] : null;
+        $returnGuzzleResponse = (isset($args[2])) ? $args[2] : false;
 
         if (in_array($function, $options)) {
-            return $this->guzzle($function, $path, $data);
+            return $this->guzzle($function, $path, $data, $returnGuzzleResponse);
         } else {
             //request verb is not in the $options array
             throw new Exception($function.' is not a valid HTTP Verb');
@@ -115,7 +116,7 @@ class Box
         ]);
     }
 
-    protected function guzzle($type, $request, $data = [])
+    protected function guzzle($type, $request, $data = [], $returnGuzzleResponse = false)
     {
         try {
             $client = new Client;
@@ -125,11 +126,14 @@ class Box
                     'Authorization' => 'Bearer '.$this->getAccessToken(),
                     'content-type' => 'application/json',
                 ],
+                'allow_redirects' => false,
                 'body' => json_encode($data),
             ]);
 
+            if($returnGuzzleResponse){
+                return $response;
+            }
             return json_decode($response->getBody()->getContents(), true);
-
         } catch (BadResponseException $e) {
             throw new BadResponseException($e->getMessage(),$e->getRequest(),$e->getResponse());
         }

--- a/src/Box.php
+++ b/src/Box.php
@@ -133,7 +133,7 @@ class Box
                 'allow_redirects' => $allowRedirects,
             ];
 
-            if (!is_null($data) && !empty($data)) {
+            if (!empty($data)) {
                 $config['body'] = json_encode($data);
             }
 


### PR DESCRIPTION
Há um bug em que toda requisição feita no DMS trigga o refresh token do BOX. Isso ocorre porque a condição de checagem está errada.

No banco de dados, guardamos em quanto tempo o token irá expirar, mas não temos a data de criação (tem a data de criação do registro na tabela, mas não é a mesma coisa).

Para sanar esse problema, vou guardar o timestamp de quando o token irá expirar em vez de dizer em quanto o tempo o token vai expirar. 